### PR TITLE
13: Fix wavy-line documentation to refer to barline element

### DIFF
--- a/schema/common.mod
+++ b/schema/common.mod
@@ -696,9 +696,9 @@
 
 <!--
 	Fermata and wavy-line elements can be applied both to
-	notes and to measures, so they are defined here. Wavy
+	notes and to barlines, so they are defined here. Wavy
 	lines are one way to indicate trills; when used with a
-	measure element, they should always have type="continue"
+	barline element, they should always have type="continue"
 	set. The fermata text content represents the shape of the
 	fermata sign and may be normal, angled, or square.
 	An empty fermata element represents a normal fermata.

--- a/schema/musicxml.xsd
+++ b/schema/musicxml.xsd
@@ -2272,7 +2272,7 @@ These letter dynamic symbols are separated from crescendo, decrescendo, and wedg
 		
 	<xs:complexType name="wavy-line">
 		<xs:annotation>
-			<xs:documentation>Wavy lines are one way to indicate trills. When used with a measure element, they should always have type="continue" set.</xs:documentation>
+			<xs:documentation>Wavy lines are one way to indicate trills. When used with a barline element, they should always have type="continue" set.</xs:documentation>
 		</xs:annotation>
 		<xs:attribute name="type" type="start-stop-continue" use="required"/>
 		<xs:attribute name="number" type="number-level"/>


### PR DESCRIPTION
Instead of the measure element
