### PR TITLE
131: Add initial tabs to note.mod documentation

### DIFF
--- a/schema/note.mod
+++ b/schema/note.mod
@@ -1189,10 +1189,10 @@
 >
 
 <!--
-    The soft-accent element indicates a soft accent that is
-    not as heavy as a normal accent. It is often notated as 
-    &lt;&gt;. It can be combined with other articulations to
-    implement the entire SMuFL Articulation Supplement range.
+	The soft-accent element indicates a soft accent that is
+	not as heavy as a normal accent. It is often notated as 
+	&lt;&gt;. It can be combined with other articulations to
+	implement the entire SMuFL Articulation Supplement range.
 -->
 <!ELEMENT soft-accent EMPTY>
 <!ATTLIST soft-accent

--- a/schema/note.mod
+++ b/schema/note.mod
@@ -1189,10 +1189,10 @@
 >
 
 <!--
-The soft-accent element indicates a soft accent that is not
-as heavy as a normal accent. It is often notated as &lt;&gt;.
-It can be combined with other articulations to implement the
-entire SMuFL Articulation Supplement range.
+    The soft-accent element indicates a soft accent that is
+    not as heavy as a normal accent. It is often notated as 
+    &lt;&gt;. It can be combined with other articulations to
+    implement the entire SMuFL Articulation Supplement range.
 -->
 <!ELEMENT soft-accent EMPTY>
 <!ATTLIST soft-accent


### PR DESCRIPTION
The original 131 pull request stripped unneeded trailing whitespace, so with all the whitespace differences we missed that the formatting of the note.mod documentation was missing initial tabs.
