### PR TITLE
Fixes: Attributes not resolving to proper attribute declaration

### DIFF
--- a/schema/musicxml.xsd
+++ b/schema/musicxml.xsd
@@ -21,8 +21,8 @@ This file defines the MusicXML 3.1 XSD, including the score-partwise and score-t
 	<xs:annotation>
 		<xs:documentation>The MusicXML 3.1 DTD has no namespace, so for compatibility the MusicXML 3.1 XSD has no namespace either. Those who need to import the MusicXML XSD into another schema are advised to create a new version that uses "http://www.musicxml.org/xsd/MusicXML" as the namespace.</xs:documentation>
 	</xs:annotation>
-	<xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.musicxml.org/xsd/xml.xsd"/>
-	<xs:import namespace="http://www.w3.org/1999/xlink" schemaLocation="http://www.musicxml.org/xsd/xlink.xsd"/>
+	<xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+	<xs:import namespace="http://www.w3.org/1999/xlink" schemaLocation="http://www.w3.org/1999/xlink.xsd"/>
 
 	<!-- Simple types derived from common.mod entities and elements -->
 


### PR DESCRIPTION
#### When trying to validate MusicXML using the given schema, it would appear that there is something wrong with the encoding.

```bash
Traceback (most recent call last):
  File "xml_validate.py", line 89, in <module>
    class_test = ValidateXML("musicxml.xsd", "test.xml")
  File "xml_validate.py", line 21, in __init__
    self.xml_schema = etree.XMLSchema(self.xmlschema_doc)
  File "src/lxml/xmlschema.pxi", line 86, in lxml.etree.XMLSchema.__init__
lxml.etree.XMLSchemaParseError: attribute use (unknown), attribute 'ref': The QName value '{http://www.w3.org/XML/1998/namespace}lang' does
not resolve to a(n) attribute declaration., line 2092
```
- We see the line in the error here:
https://github.com/w3c/musicxml/blob/33bfbcc7b428db21c20f413fb03109e64ef92f69/schema/musicxml.xsd#L2092

- with the only place `http://www.w3.org/XML/1998/namespace` being referenced is here.
https://github.com/w3c/musicxml/blob/33bfbcc7b428db21c20f413fb03109e64ef92f69/schema/musicxml.xsd#L24-L25

- Changing these two lines makes the validation possible, but there might be a better solution.

#### Attached script for verification

```python
from collections import namedtuple
from io import StringIO, BytesIO
import os

from lxml import etree

class ValidateXML:
  def __init__(self, schema_filepath, testxml_filepath):
    self.schema_filepath = schema_filepath
    self.testxml_filepath = testxml_filepath
    self.output = namedtuple("ValidateXML", ["status", "schema_file", "test_file"])

    with open(self.schema_filepath, "r") as f_schema:
      self.schema = StringIO(f_schema.read())
    with open(self.testxml_filepath, "rb") as t_schema:
      self.test = BytesIO(t_schema.read())

    self.xmlschema_doc = etree.parse(self.schema_filepath)
    self.xml_schema = etree.XMLSchema(self.xmlschema_doc)

  def isvalid(self):
    status = self.xml_schema.validate( etree.parse(self.test) )
    return self.output(status, self.schema_filepath, self.testxml_filepath)

class_test = ValidateXML("musicxml.xsd", "test.xml")
print(class_test.isvalid())
```
