### PR TITLE
Change whistle.tin to whistle.tin.c

### DIFF
--- a/schema/sounds.xml
+++ b/schema/sounds.xml
@@ -777,8 +777,8 @@
    <sound id="wind.flutes.whistle.low-irish"/>
    <sound id="wind.flutes.whistle.shiva"/>
    <sound id="wind.flutes.whistle.slide"/>
-   <sound id="wind.flutes.whistle.tin"/>
    <sound id="wind.flutes.whistle.tin.bflat"/>
+   <sound id="wind.flutes.whistle.tin.c"/>
    <sound id="wind.flutes.whistle.tin.d"/>
    <sound id="wind.flutes.xiao"/>
    <sound id="wind.flutes.xun"/>


### PR DESCRIPTION
As covered in issue  #289 'wind.flutes.whistle.tin does not designate a valid sound ID'
having an id of "wind.flutes.whistle.tin" is not appropriate for the Tin Whistle, unless it is a whistle tuned to D - not C as implied by the existing schema. By far the most common whistle is tuned to D, followed by C and B flat. Hence this change is to make the tuning explicit.
In future it would be good to add the other high tin whistles which are E flat, F and G.