### PR TITLE
fix #289: add whistle.tin.c

### DIFF
--- a/schema/sounds.xml
+++ b/schema/sounds.xml
@@ -779,6 +779,7 @@
    <sound id="wind.flutes.whistle.slide"/>
    <sound id="wind.flutes.whistle.tin"/>
    <sound id="wind.flutes.whistle.tin.bflat"/>
+   <sound id="wind.flutes.whistle.tin.c"/>
    <sound id="wind.flutes.whistle.tin.d"/>
    <sound id="wind.flutes.xiao"/>
    <sound id="wind.flutes.xun"/>


### PR DESCRIPTION
As per the discussion at https://github.com/w3c/musicxml/issues/289 we have agreed to add whistle.tin.c. rather than replace whistle.tin with whistle.tin.c