### PR TITLE
fix documentation in midi numeric types

### DIFF
--- a/schema/musicxml.xsd
+++ b/schema/musicxml.xsd
@@ -222,7 +222,7 @@ As in SVG 1.1, colors are defined in terms of the sRGB color space (IEC 61966).<
 
 	<xs:simpleType name="midi-128">
 		<xs:annotation>
-			<xs:documentation>The midi-16 type is used to express MIDI 1.0 values that range from 1 to 128.</xs:documentation>
+			<xs:documentation>The midi-128 type is used to express MIDI 1.0 values that range from 1 to 128.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:positiveInteger">
 			<xs:minInclusive value="1"/>
@@ -232,7 +232,7 @@ As in SVG 1.1, colors are defined in terms of the sRGB color space (IEC 61966).<
 
 	<xs:simpleType name="midi-16384">
 		<xs:annotation>
-			<xs:documentation>The midi-16 type is used to express MIDI 1.0 values that range from 1 to 16,384.</xs:documentation>
+			<xs:documentation>The midi-16384 type is used to express MIDI 1.0 values that range from 1 to 16,384.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:positiveInteger">
 			<xs:minInclusive value="1"/>


### PR DESCRIPTION
Came across a couple of small typos. I didn't see this same documentation text in the DTDs.

-- disclaimer

I am a member of the w3c Music Notation Community Group and
I agree to participate in the Music Notation Community Group [1] under the 
terms of the Community and Business Group Process [2], agree to abide by 
the terms and spirit of the Code of Ethics and Professional Conduct [3], 
and agree to participate as an individual under the W3C Community Contributor License Agreement [4]. 

For more information on Music Notation Community Group participation, see: 
w3.org/community/music-notation 

[1] w3.org/community/music-notation 
[2] w3.org/community/agreements 
[3] w3.org/Consortium/cepc 
[4] w3.org/community/agreements/cla 