### PR TITLE
285: Update imported schemaLocation attributes

### DIFF
--- a/schema/musicxml.xsd
+++ b/schema/musicxml.xsd
@@ -21,8 +21,8 @@ This file defines the MusicXML 4.0 XSD, including the score-partwise and score-t
 	<xs:annotation>
 		<xs:documentation>The MusicXML 4.0 DTD has no namespace, so for compatibility the MusicXML 4.0 XSD has no namespace either. Those who need to import the MusicXML XSD into another schema are advised to create a new version that uses "http://www.musicxml.org/xsd/MusicXML" as the namespace.</xs:documentation>
 	</xs:annotation>
-	<xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.musicxml.org/xsd/xml.xsd"/>
-	<xs:import namespace="http://www.w3.org/1999/xlink" schemaLocation="http://www.musicxml.org/xsd/xlink.xsd"/>
+	<xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
+	<xs:import namespace="http://www.w3.org/1999/xlink" schemaLocation="xlink.xsd"/>
 
 	<!-- Simple types derived from common.mod entities and elements -->
 


### PR DESCRIPTION
Pull request #284 is not quite right as the MusicXML xlink.xsd is a subset of the W3C version. This pull request uses @infojunkie's suggestion to use a relative schemaLocation as the two files being imported should always be in the same folder. I confirmed that this works with lxml validating against a local copy of musicxml.xsd, and does not break the entity resolver approach used in Finale.