### PR TITLE
Fix #8: Clarify document vs. score order

### DIFF
--- a/schema/common.mod
+++ b/schema/common.mod
@@ -97,6 +97,16 @@
 	attached to a single note, such as a tie leading into or
 	out of a repeated section or coda, use two tied elements on
 	the same note, one start and one stop.
+	
+	When multiple elements with the same tag are used within the
+	same note, their order within the MusicXML document should
+	match the musical score order. For example, a note that 
+	marks both the end of one slur and the start of a new slur
+	should have the incoming slur element with a type of stop
+	precede the outgoing slur element with a type of start. A
+	note with a tie at the end of a first ending should have the
+	tied element with a type of start precede the tied element
+	with a type of stop.
 
 	In start-stop cases, ties can add more elements using a
 	continue type. This is typically used to specify the
@@ -172,15 +182,47 @@
 	  octagon | nonagon | decagon | none)">
 
 <!--
-	Slurs, tuplets, and many other features can be
-	concurrent and overlapping within a single musical
-	part. The number-level attribute distinguishes up to
-	six concurrent objects of the same type. A reading
-	program should be prepared to handle cases where
-	the number-levels stop in an arbitrary order.
-	Different numbers are needed when the features
-	overlap in MusicXML document order. When a number-level
-	value is implied, the value is 1 by default.
+	Slurs, tuplets, and many other features can be concurrent
+	and overlap within a single musical part. The number-level
+	entity distinguishes up to six concurrent objects of the
+	same type when the objects overlap in MusicXML document
+	order. When a number-level value is implied, the value is
+	1 by default.
+	
+	When polyphonic parts are involved, the ordering within a
+	MusicXML document can differ from musical score order. As
+	an example, say we have a piano part in 4/4 where within a
+	single measure, all the notes on the top staff are followed
+	by all the notes on the bottom staff. In this example, each
+	staff has a slur that starts on beat 2 and stops on beat 3,
+	and there is a third slur that goes from beat 1 of one staff
+	to beat 4 of the other staff.
+	
+	In this situation, the two mid-measure slurs can use the
+	same number because they do not overlap in MusicXML document
+	order, even though they do overlap in musical score order.
+	Within the MusicXMLXML document, the top staff slur will
+	both start and stop before the bottom staff slur starts and
+	stops.
+	
+	If the cross-staff slur starts in the top staff and stops
+	in the bottom staff, it will need a separate number from
+	the mid-measure slurs because it overlaps those slurs in
+	MusicXML document order. However, if the cross-staff slur
+	starts in the bottom staff and stops in the top staff, all
+	three slurs can use the same number. None of them overlap
+	within the MusicXML document, even though they all overlap
+	each other in the musical score order. Within the MusicXML
+	document, the start and stop of the top-staff slur will
+	be followed by the stop and start of the cross-staff slur,
+	followed by the start and stop of the bottom-staff slur.
+	
+	As this example demonstrates, a reading program should be
+	prepared to handle cases where the number-levels start and
+	stop in an arbitrary order. Because the start and stop
+	values refer to musical score order, a program may find the
+	stopping point of an object earlier in the MusicXML document
+	than it will find its starting point.
 -->
 <!ENTITY % number-level "(1 | 2 | 3 | 4 | 5 | 6)">
 

--- a/schema/musicxml.xsd
+++ b/schema/musicxml.xsd
@@ -277,7 +277,15 @@ As in SVG 1.1, colors are defined in terms of the sRGB color space (IEC 61966).<
 
 	<xs:simpleType name="number-level">
 		<xs:annotation>
-			<xs:documentation>Slurs, tuplets, and many other features can be concurrent and overlapping within a single musical part. The number-level type distinguishes up to six concurrent objects of the same type. A reading program should be prepared to handle cases where the number-levels stop in an arbitrary order. Different numbers are needed when the features overlap in MusicXML document order. When a number-level value is optional, the value is 1 by default.</xs:documentation>
+			<xs:documentation>Slurs, tuplets, and many other features can be concurrent and overlap within a single musical part. The number-level entity distinguishes up to six concurrent objects of the same type when the objects overlap in MusicXML document order. When a number-level value is implied, the value is 1 by default.
+				
+When polyphonic parts are involved, the ordering within a MusicXML document can differ from musical score order. As an example, say we have a piano part in 4/4 where within a single measure, all the notes on the top staff are followed by all the notes on the bottom staff. In this example, each staff has a slur that starts on beat 2 and stops on beat 3, and there is a third slur that goes from beat 1 of one staff to beat 4 of the other staff.
+				
+In this situation, the two mid-measure slurs can use the same number because they do not overlap in MusicXML document order, even though they do overlap in musical score order. Within the MusicXML document, the top staff slur will both start and stop before the bottom staff slur starts and stops.
+				
+If the cross-staff slur starts in the top staff and stops in the bottom staff, it will need a separate number from the mid-measure slurs because it overlaps those slurs in MusicXML document order. However, if the cross-staff slur starts in the bottom staff and stops in the top staff, all three slurs can use the same number. None of them overlap within the MusicXML document, even though they all overlap each other in the musical score order. Within the MusicXML document, the start and stop of the top-staff slur will be followed by the stop and start of the cross-staff slur, followed by the start and stop of the bottom-staff slur.
+				
+As this example demonstrates, a reading program should be prepared to handle cases where the number-levels start and stop in an arbitrary order. Because the start and stop values refer to musical score order, a program may find the stopping point of an object earlier in the MusicXML document than it will find its starting point.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:positiveInteger">
 			<xs:minInclusive value="1"/>
@@ -460,7 +468,9 @@ As in SVG 1.1, colors are defined in terms of the sRGB color space (IEC 61966).<
 		<xs:annotation>
 			<xs:documentation>The start-stop type is used for an attribute of musical elements that can either start or stop, such as tuplets.
 
-The values of start and stop refer to how an element appears in musical score order, not in MusicXML document order. An element with a stop attribute may precede the corresponding element with a start attribute within a MusicXML document. This is particularly common in multi-staff music. For example, the stopping point for a tuplet may appear in staff 1 before the starting point for the tuplet appears in staff 2 later in the document.</xs:documentation>
+The values of start and stop refer to how an element appears in musical score order, not in MusicXML document order. An element with a stop attribute may precede the corresponding element with a start attribute within a MusicXML document. This is particularly common in multi-staff music. For example, the stopping point for a tuplet may appear in staff 1 before the starting point for the tuplet appears in staff 2 later in the document.
+
+When multiple elements with the same tag are used within the same note, their order within the MusicXML document should match the musical score order.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:token">
 			<xs:enumeration value="start"/>
@@ -472,7 +482,9 @@ The values of start and stop refer to how an element appears in musical score or
 		<xs:annotation>
 			<xs:documentation>The start-stop-continue type is used for an attribute of musical elements that can either start or stop, but also need to refer to an intermediate point in the symbol, as for complex slurs or for formatting of symbols across system breaks.
 
-The values of start, stop, and continue refer to how an element appears in musical score order, not in MusicXML document order. An element with a stop attribute may precede the corresponding element with a start attribute within a MusicXML document. This is particularly common in multi-staff music. For example, the stopping point for a slur may appear in staff 1 before the starting point for the slur appears in staff 2 later in the document.</xs:documentation>
+The values of start, stop, and continue refer to how an element appears in musical score order, not in MusicXML document order. An element with a stop attribute may precede the corresponding element with a start attribute within a MusicXML document. This is particularly common in multi-staff music. For example, the stopping point for a slur may appear in staff 1 before the starting point for the slur appears in staff 2 later in the document.
+
+When multiple elements with the same tag are used within the same note, their order within the MusicXML document should match the musical score order. For example, a note that marks both the end of one slur and the start of a new slur should have the incoming slur element with a type of stop precede the outgoing slur element with a type of start.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:token">
 			<xs:enumeration value="start"/>
@@ -483,7 +495,9 @@ The values of start, stop, and continue refer to how an element appears in music
 
 	<xs:simpleType name="start-stop-single">
 		<xs:annotation>
-			<xs:documentation>The start-stop-single type is used for an attribute of musical elements that can be used for either multi-note or single-note musical elements, as for groupings.</xs:documentation>
+			<xs:documentation>The start-stop-single type is used for an attribute of musical elements that can be used for either multi-note or single-note musical elements, as for groupings.
+
+When multiple elements with the same tag are used within the same note, their order within the MusicXML document should match the musical score order.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:token">
 			<xs:enumeration value="start"/>
@@ -536,7 +550,9 @@ Distances in a MusicXML file are measured in tenths of staff space. Tenths are t
 		<xs:annotation>
 			<xs:documentation>The tied-type type is used as an attribute of the tied element to specify where the visual representation of a tie begins and ends. A tied element which joins two notes of the same pitch can be specified with tied-type start on the first note and tied-type stop on the second note. To indicate a note should be undamped, use a single tied element with tied-type let-ring. For other ties that are visually attached to a single note, such as a tie leading into or out of a repeated section or coda, use two tied elements on the same note, one start and one stop.
 
-In start-stop cases, ties can add more elements using a continue type. This is typically used to specify the formatting of cross-system ties.</xs:documentation>
+In start-stop cases, ties can add more elements using a continue type. This is typically used to specify the formatting of cross-system ties.
+
+When multiple elements with the same tag are used within the same note, their order within the MusicXML document should match the musical score order. For example, a note with a tie at the end of a first ending should have the tied element with a type of start precede the tied element with a type of stop.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:token">
 			<xs:enumeration value="start"/>


### PR DESCRIPTION
Clarifications for both the number attribute and for repeated start-stop elements within a single note.