### PR TITLE
harmony-type typo

### DIFF
--- a/docs/musicxml-reference/data-types/harmony-type/index.html
+++ b/docs/musicxml-reference/data-types/harmony-type/index.html
@@ -108,7 +108,7 @@
 <h1>harmony-type data type</h1>
 
 
-<p>The harmony-type type differentiates different types of harmonies when alternate harmonies are possible.</p>
+<p>The harmony-type type differentiates different types of harmonies when alternate harmonies are possible.  Explicit harmonies have all notes present in the music; implied have some notes missing but implied; alternate represents alternate analyses.</p>
 
 
 

--- a/docs/musicxml-reference/data-types/harmony-type/index.html
+++ b/docs/musicxml-reference/data-types/harmony-type/index.html
@@ -108,7 +108,7 @@
 <h1>harmony-type data type</h1>
 
 
-<p>The harmony-type type differentiates different types of harmonies when alternate harmonies are possible.  Explicit harmonies have all notes present in the music; implied have some notes missing but implied; alternate represents alternate analyses.</p>
+<p>The harmony-type type differentiates different types of harmonies when alternate harmonies are possible. Explicit harmonies have all notes present in the music; implied have some notes missing but implied; alternate represents alternate analyses.</p>
 
 
 

--- a/doctools/musicxmldoc.json
+++ b/doctools/musicxmldoc.json
@@ -2963,7 +2963,7 @@
         "name": "harmony-type",
         "slug": "harmony-type",
         "schema": 1,
-        "description": "The harmony-type type differentiates different types of harmonies when alternate harmonies are possible.  Explicit harmonies have all notes present in the music; implied have some notes missing but implied; alternate represents alternate analyses.",
+        "description": "The harmony-type type differentiates different types of harmonies when alternate harmonies are possible. Explicit harmonies have all notes present in the music; implied have some notes missing but implied; alternate represents alternate analyses.",
         "description_format": 1,
         "is_featured": false,
         "xsd_name": "",

--- a/doctools/musicxmldoc.json
+++ b/doctools/musicxmldoc.json
@@ -2963,7 +2963,7 @@
         "name": "harmony-type",
         "slug": "harmony-type",
         "schema": 1,
-        "description": "The harmony-type type differentiates different types of harmonies when alternate harmonies are possible.",
+        "description": "The harmony-type type differentiates different types of harmonies when alternate harmonies are possible.  Explicit harmonies have all notes present in the music; implied have some notes missing but implied; alternate represents alternate analyses.",
         "description_format": 1,
         "is_featured": false,
         "xsd_name": "",

--- a/schema/musicxml.xsd
+++ b/schema/musicxml.xsd
@@ -1039,7 +1039,7 @@ The none sign is deprecated as of MusicXML 4.0. Use the clef element's print-obj
 	
 	<xs:simpleType name="harmony-type">
 		<xs:annotation>
-			<xs:documentation>The harmony-type type differentiates different types of harmonies when alternate harmonies are possible. Explicit harmonies have all note present in the music; implied have some notes missing but implied; alternate represents alternate analyses.</xs:documentation>
+			<xs:documentation>The harmony-type type differentiates different types of harmonies when alternate harmonies are possible. Explicit harmonies have all notes present in the music; implied have some notes missing but implied; alternate represents alternate analyses.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:token">
 			<xs:enumeration value="explicit"/>


### PR DESCRIPTION
Thanks to @rettinghaus for noticing. In fact, the problem was bigger since some parts of the docs were missing the whole second sentence.

Fixes #594 